### PR TITLE
Script to cleanup unused Icons

### DIFF
--- a/tools/cleanup_icons.py
+++ b/tools/cleanup_icons.py
@@ -1,0 +1,53 @@
+import re
+import json
+import pathlib
+from os import remove
+
+
+iconset_mapping = {
+    "Fas": "font-awesome-solid",
+    "Fab": "font-awesome-brands",
+    "Far": "font-awesome-regular",
+    "Ri": "remix-icons",
+    "Si": "simple-icons",
+    "Li": "lucide-icons",
+    "Ib": "icon-brew",
+}
+
+cur_path = pathlib.Path(__file__).parent.resolve()
+icons_path = pathlib.Path(cur_path, "icons")
+
+files_used = []
+with open(pathlib.Path(cur_path, "data.json"), "r") as f:
+    data = json.load(f)
+    data.pop("settings")
+    icons = set(data.values())
+    for icon in icons:
+        name_splitted = list(filter(None, re.split("([A-Z0-9_-][^A-Z0-9_-]+)", icon)))
+        iconset_foldername = iconset_mapping[name_splitted.pop(0)]
+        normalized_name = "".join(
+            [t.replace("-", "").replace("_", "").capitalize() for t in name_splitted]
+        )
+        # print(icon, iconset_foldername, name_splitted, normalized_name)
+        files_used.append(
+            pathlib.Path(icons_path, iconset_foldername, normalized_name + ".svg")
+        )
+
+files_to_remove, files_to_keep = [], []
+
+for icon in pathlib.Path(cur_path, "icons").glob("**/*.svg"):
+    (files_to_remove if icon not in files_used else files_to_keep).append(icon)
+
+if len(files_used) != len(files_to_keep):
+    print(
+        f"Warning: `data.json` assigned {len(files_used)} unique icons, but only {len(files_to_keep)} of those have been found on the disk."
+    )
+print(f"Delete {len(files_to_remove)} files (keep {len(files_to_keep)})? (y/N)")
+
+if input().lower() in {"yes", "y", "ye"}:
+    print("Deleting...")
+    for f in files_to_remove:
+        f.unlink()
+    print(f"Deleted {len(files_to_remove)} icon files.")
+else:
+    print("Nothing was deleted.")

--- a/tools/cleanup_icons.py
+++ b/tools/cleanup_icons.py
@@ -15,10 +15,11 @@ iconset_mapping = {
 }
 
 cur_path = pathlib.Path(__file__).parent.resolve()
+data_file = pathlib.Path(cur_path, "data.json")
 icons_path = pathlib.Path(cur_path, "icons")
 
 files_used = []
-with open(pathlib.Path(cur_path, "data.json"), "r") as f:
+with open(data_file, "r") as f:
     data = json.load(f)
     data.pop("settings")
     icons = set(data.values())
@@ -35,12 +36,20 @@ with open(pathlib.Path(cur_path, "data.json"), "r") as f:
 
 files_to_remove, files_to_keep = [], []
 
-for icon in pathlib.Path(cur_path, "icons").glob("**/*.svg"):
+for icon in icons_path.glob("**/*.svg"):
     (files_to_remove if icon not in files_used else files_to_keep).append(icon)
 
 if len(files_used) != len(files_to_keep):
     print(
         f"Warning: `data.json` assigned {len(files_used)} unique icons, but only {len(files_to_keep)} of those have been found on the disk."
+    )
+    print(
+        "could not find the following icons on disk:",
+        [
+            str(f.relative_to(icons_path)).replace("\\", "/")
+            for f in files_used
+            if f not in files_to_keep
+        ],
     )
 print(f"Delete {len(files_to_remove)} files (keep {len(files_to_keep)})? (y/N)")
 


### PR DESCRIPTION
As discussed in #153, having a lot of icons in the folder leads to syncing errors and a high vault size.

If you have a rather static set of icons, you can now use the attached script to delete all unused icons.

All you need to do is download this file into the ``obsidian\plugins\obsidian-icon-folder`` folder and run it.

Unfortunately, I do not have much experience in developing typescript-based scripts and plugins, so I wrote this in Python.

Future Ideas:
- Translate it to Typescript and integrate it into the options page of your plugin
- Add a button to the option page of your plugin that redownloads every icon pack (for easier adding of items after using this script) 

In my case, the scripts outputs the following:
```
Warning: `data.json` assigned 90 unique icons, but only 42 of those have been found on the disk.
Delete 7328 files (keep 42)? (y/N)
y
Deleting...
Deleted 7328 icon files.
```
(the icons that are assigned but not found on disk are likely due to deleted pages or icon files that have been lost during sync) 